### PR TITLE
chore(deps): migrate pnpm overrides to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,22 +142,6 @@
     "vite-plugin-dts": "4.5.4",
     "vitest": "4.0.18"
   },
-  "pnpm": {
-    "ignoredBuiltDependencies": [
-      "@parcel/watcher",
-      "@swc/core",
-      "esbuild",
-      "less",
-      "lmdb",
-      "msgpackr-extract",
-      "nx",
-      "rollup",
-      "unrs-resolver"
-    ],
-    "overrides": {
-      "qs": ">=6.14.1"
-    }
-  },
   "lint-staged": {
     "*.{ts,js,html,css,scss,json,md}": [
       "prettier --write"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  qs: '>=6.14.1'
+
 importers:
 
   .:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,19 @@
 packages:
   - 'apps/*'
   - 'packages/*'
+
+# pnpm v9+ reads overrides and ignoredBuiltDependencies from pnpm-workspace.yaml,
+# not from the "pnpm" field in package.json.
+overrides:
+  qs: '>=6.14.1'
+
+ignoredBuiltDependencies:
+  - '@parcel/watcher'
+  - '@swc/core'
+  - esbuild
+  - less
+  - lmdb
+  - msgpackr-extract
+  - nx
+  - rollup
+  - unrs-resolver


### PR DESCRIPTION
pnpm v9+ no longer reads the 'pnpm' field from package.json. Move overrides and ignoredBuiltDependencies to pnpm-workspace.yaml and regenerate lockfile to fix ERR_PNPM_LOCKFILE_CONFIG_MISMATCH in CI.