### PR TITLE
fix(ci): align pnpm version to 11 to match local lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 9
+          version: 11
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 9
+          version: 11
 
       - uses: actions/setup-node@v6
         with:

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     ]
   },
   "private": true,
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@acontplus/core": "workspace:^",
     "@acontplus/ng-auth": "workspace:^",


### PR DESCRIPTION
Lockfile was generated with pnpm 11 (lockfileVersion 9.0) but workflows pinned pnpm 9, causing ERR_PNPM_LOCKFILE_CONFIG_MISMATCH. Bump workflows to pnpm 11 and add packageManager field to prevent future version drift.