### PR TITLE
fix(ci): remove explicit pnpm version from workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
           filter: tree:0
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 11
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,6 @@ jobs:
           token: ${{ secrets.RELEASE_TOKEN }}
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 11
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
pnpm/action-setup@v6 reads the version from packageManager field in package.json. Specifying version in both places causes: 'Error: Multiple versions of pnpm specified'