### PR TITLE
fix(ci): remove registry-url from setup-node to unblock OIDC publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,9 @@ jobs:
           # publishing requirement of >= 11.5.1. No manual npm upgrade needed.
           node-version: 24
           cache: 'pnpm'
-          # registry-url configures .npmrc so npm CLI knows which registry to
-          # target for OIDC token exchange during publish.
-          registry-url: 'https://registry.npmjs.org'
+          # Do NOT set registry-url here — setup-node injects NODE_AUTH_TOKEN
+          # into every subsequent step when registry-url is set, which takes
+          # precedence over OIDC and causes 404 auth failures on npm publish.
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
actions/setup-node with registry-url injects NODE_AUTH_TOKEN into all subsequent steps via .npmrc. npm CLI sees this token first and tries to use it for auth — but it's the GitHub Actions default token with no npm publish permissions, causing 404 errors on every package.

With OIDC trusted publishing, NODE_AUTH_TOKEN must NOT be present during npm publish. The registry is already configured in .npmrc so registry-url is not needed. npm 11 auto-detects the OIDC environment when no auth token is present and exchanges it for a publish token.

Ref: https://docs.npmjs.com/trusted-publishers