### PR TITLE
chore(release): add conventional commit type config and fix repositor…

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -84,6 +84,21 @@
       "updateDependents": "auto",
       "preserveLocalDependencyProtocols": false
     },
+    "conventionalCommits": {
+      "types": {
+        "feat": { "semverBump": "minor", "changelog": { "title": "Features" } },
+        "fix": { "semverBump": "patch", "changelog": { "title": "Bug Fixes" } },
+        "perf": { "semverBump": "patch", "changelog": { "title": "Performance Improvements" } },
+        "refactor": { "semverBump": "patch", "changelog": { "title": "Refactoring" } },
+        "docs": { "semverBump": "none", "changelog": { "hidden": true } },
+        "chore": { "semverBump": "none", "changelog": { "hidden": true } },
+        "ci": { "semverBump": "none", "changelog": false },
+        "test": { "semverBump": "none", "changelog": { "hidden": true } },
+        "build": { "semverBump": "none", "changelog": { "hidden": true } },
+        "style": { "semverBump": "none", "changelog": { "hidden": true } },
+        "revert": { "semverBump": "patch", "changelog": { "title": "Reverts" } }
+      }
+    },
     "changelog": {
       "workspaceChangelog": {
         "createRelease": "github"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,7 +64,7 @@
   "homepage": "https://github.com/acontplus/acontplus-libs#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/acontplus/acontplus-libs.git"
+    "url": "git+https://github.com/acontplus/acontplus-libs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ng-auth/package.json
+++ b/packages/ng-auth/package.json
@@ -68,7 +68,7 @@
   "homepage": "https://github.com/acontplus/acontplus-libs#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/acontplus/acontplus-libs.git"
+    "url": "git+https://github.com/acontplus/acontplus-libs.git"
   },
   "release": {
     "branches": [

--- a/packages/ng-common/package.json
+++ b/packages/ng-common/package.json
@@ -53,7 +53,7 @@
   "homepage": "https://github.com/acontplus/acontplus-libs#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/acontplus/acontplus-libs.git"
+    "url": "git+https://github.com/acontplus/acontplus-libs.git"
   },
   "release": {
     "branches": [

--- a/packages/ng-components/package.json
+++ b/packages/ng-components/package.json
@@ -74,7 +74,7 @@
   "homepage": "https://github.com/acontplus/acontplus-libs#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/acontplus/acontplus-libs.git"
+    "url": "git+https://github.com/acontplus/acontplus-libs.git"
   },
   "release": {
     "branches": [

--- a/packages/ng-config/package.json
+++ b/packages/ng-config/package.json
@@ -47,7 +47,7 @@
   "homepage": "https://github.com/acontplus/acontplus-libs#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/acontplus/acontplus-libs.git"
+    "url": "git+https://github.com/acontplus/acontplus-libs.git"
   },
   "release": {
     "branches": [

--- a/packages/ng-customer/package.json
+++ b/packages/ng-customer/package.json
@@ -47,7 +47,7 @@
   "homepage": "https://github.com/acontplus/acontplus-libs#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/acontplus/acontplus-libs.git"
+    "url": "git+https://github.com/acontplus/acontplus-libs.git"
   },
   "release": {
     "branches": [

--- a/packages/ng-infrastructure/package.json
+++ b/packages/ng-infrastructure/package.json
@@ -63,7 +63,7 @@
   "homepage": "https://github.com/acontplus/acontplus-libs#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/acontplus/acontplus-libs.git"
+    "url": "git+https://github.com/acontplus/acontplus-libs.git"
   },
   "release": {
     "branches": [

--- a/packages/ng-notifications/package.json
+++ b/packages/ng-notifications/package.json
@@ -58,7 +58,7 @@
   "homepage": "https://github.com/acontplus/acontplus-libs#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/acontplus/acontplus-libs.git"
+    "url": "git+https://github.com/acontplus/acontplus-libs.git"
   },
   "release": {
     "branches": [

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -54,7 +54,7 @@
   "homepage": "https://github.com/acontplus/acontplus-libs#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/acontplus/acontplus-libs.git"
+    "url": "git+https://github.com/acontplus/acontplus-libs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -56,7 +56,7 @@
   "homepage": "https://github.com/acontplus/acontplus-libs#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/acontplus/acontplus-libs.git"
+    "url": "git+https://github.com/acontplus/acontplus-libs.git"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
…y.url

Versioning strategy per https://www.conventionalcommits.org:
- feat → minor bump (new features)
- fix / perf / refactor / revert → patch bump
- BREAKING CHANGE or feat!/fix! → major bump
- docs / chore / ci / test / build / style → no version bump, hidden in changelog

Fix: add git+ prefix to repository.url in all packages/*/package.json so npm does not auto-correct and warn on every publish.